### PR TITLE
Fix inconsistent head of file behavior

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     runtimeOnly("ch.qos.logback:logback-classic")
     testImplementation("io.micronaut:micronaut-http-client")
     testImplementation("org.assertj:assertj-core")
+    testImplementation("org.awaitility:awaitility:4.2.0")
 }
 
 

--- a/src/test/java/qlog/TailReaderTest.java
+++ b/src/test/java/qlog/TailReaderTest.java
@@ -1,7 +1,6 @@
 package qlog;
 
 import org.assertj.core.api.WithAssertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -10,6 +9,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.awaitility.Awaitility.await;
 
 public class TailReaderTest implements WithAssertions {
 
@@ -95,6 +97,24 @@ public class TailReaderTest implements WithAssertions {
                         "Told by an idiot, full of sound and fury,",
                         "That struts and frets his hour upon the stage,",
                         "Life's but a walking shadow, a poor player,"));
+    }
+
+    @Test
+    void testOneLineFileWithFilter() {
+        var path = getPathToResource("smallfile");
+        var reader = new TailReaderImpl(65536);
+        await().atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, 10, "WONTFIND"))
+                        .isEmpty());
+    }
+
+    @Test
+    void testFilterNoMatches() {
+        var path = getPathToResource("macbeth.txt");
+        var reader = new TailReaderImpl(65536);
+        await().atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, 10, "WONTFIND"))
+                        .isEmpty());
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/test/resources/smallfile
+++ b/src/test/resources/smallfile
@@ -1,0 +1,1 @@
+one line


### PR DESCRIPTION
Context

- When reading a file with a filter, the reader impl will
  chunk through the file searching for lines until it reaches
  the head of the file. That is, it will try to read the
  entire file looking for a match against the filter.
- The reader should stop when: enough lines are collected
  (ie. matching the filter) OR when the head of the file
  is reached (ie. there are no more bytes to read).

What's Changed?

- The reader impl will now break out of reading chunks from
  the file when the head of the file is reached. (When
  bytesRead is gte the channel size.)
- Flushing the lineBuffer into the result set was refactored
  so that both cases when the buffer needs to be flushed into
  results (1. when a newline char is found, and 2. at the
  head of the file) share the same logic.

How Was This Tested?

- Using curl: `curl -i -Ss "http://localhost:8080/queryLog?relativePath=smallfile&filter=WILLNOTFIND"`
- Added unit tests using awaitility to assert reader finishes
  in a reasonable amount of time.

Fixes #1 