### PR TITLE
Fix loop while reading empty file

### DIFF
--- a/src/main/java/qlog/TailReaderImpl.java
+++ b/src/main/java/qlog/TailReaderImpl.java
@@ -47,6 +47,10 @@ public class TailReaderImpl implements TailReader {
         // This approach requires use of a SeekableByteChannel so that we can manually control
         // position of the channel while reading the chunks.
         try (var ch = Files.newByteChannel(path, StandardOpenOption.READ)) {
+            if (ch.size() == 0) {
+                // The file is empty, so there will never be any lines to collect.
+                return collectedLines;
+            }
             // The start of the chunk is the end (channel size) minus the capacity (limit) of the buffer.
             // If the file is smaller than the buffer we do not allow start to be negative so take the max of 0.
             var start = Math.max(0, ch.size() - bb.limit());

--- a/src/test/java/qlog/TailReaderTest.java
+++ b/src/test/java/qlog/TailReaderTest.java
@@ -117,6 +117,15 @@ public class TailReaderTest implements WithAssertions {
                         .isEmpty());
     }
 
+    @Test
+    void noLinesFromEmptyFile() {
+        var path = getPathToResource("empty.txt");
+        var reader = new TailReaderImpl(65536);
+        await().atMost(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, 10, null))
+                        .isEmpty());
+    }
+
     @SuppressWarnings("SameParameterValue")
     private Path getPathToResource(String fileName) {
         var resourceURL = getClass().getClassLoader().getResource(fileName);


### PR DESCRIPTION
Context

- When reading an empty file the reader would
  loop by reading 0 bytes and never reach
  an expected end condition.

What's Changed?

- Update the reader to return when the file
  channel is empty.

How Was This Tested?

- `curl http://localhost:8080/queryLog?relativePath=empty`
  returns 200 OK.
- Added test case for empty file.

Fixes #4