### PR TITLE
Implement pagination with continuation tokens

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,8 @@ repositories {
 dependencies {
     annotationProcessor("io.micronaut:micronaut-http-validation")
     annotationProcessor("io.micronaut.serde:micronaut-serde-processor")
+    annotationProcessor("io.micronaut.validation:micronaut-validation-processor")
+    implementation("io.micronaut.validation:micronaut-validation")
     implementation("io.micronaut.serde:micronaut-serde-jackson")
     compileOnly("io.micronaut:micronaut-http-client")
     runtimeOnly("ch.qos.logback:logback-classic")

--- a/src/main/java/qlog/TailReader.java
+++ b/src/main/java/qlog/TailReader.java
@@ -10,13 +10,16 @@ public interface TailReader {
     /**
      * Get the last N lines from a file.
      *
-     * @param path   A path to the file to read lines from.
-     * @param filter If present, a line is counted only when it matches the filter.
-     * @param start  The line number to start reading from. 0 is the last line.
-     * @param count  The number of lines to read out in the returned List.
+     * @param path              A path to the file to read lines from.
+     * @param filter            If present, a line is counted only when it matches the filter.
+     * @param continuationToken A token the reader will use to continue reading at a byte position in the file.
+     *                          This reader will issue a continuationToken in the result if there are more bytes
+     *                          to read in the file.
+     * @param start             The line number to start reading from. 0 is the last line.
+     * @param count             The number of lines to read out in the returned List.
      * @return A List of lines ordered with the newest entries at the head of the List.
      */
-    ReaderResult getLastNLines(Path path, @Nullable String filter, int start, int count);
+    ReaderResult getLastNLines(Path path, @Nullable String filter, String continuationToken, int start, int count);
 
     record ReaderResult(List<String> lines, Optional<String> continuationToken) {
     }

--- a/src/main/java/qlog/TailReader.java
+++ b/src/main/java/qlog/TailReader.java
@@ -4,6 +4,7 @@ import jakarta.annotation.Nullable;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 public interface TailReader {
     /**
@@ -15,5 +16,8 @@ public interface TailReader {
      * @param count  The number of lines to read out in the returned List.
      * @return A List of lines ordered with the newest entries at the head of the List.
      */
-    List<String> getLastNLines(Path path, @Nullable String filter, int start, int count);
+    ReaderResult getLastNLines(Path path, @Nullable String filter, int start, int count);
+
+    record ReaderResult(List<String> lines, Optional<String> continuationToken) {
+    }
 }

--- a/src/main/java/qlog/TailReader.java
+++ b/src/main/java/qlog/TailReader.java
@@ -11,8 +11,9 @@ public interface TailReader {
      *
      * @param path   A path to the file to read lines from.
      * @param filter If present, a line is counted only when it matches the filter.
+     * @param start  The line number to start reading from. 0 is the last line.
      * @param count  The number of lines to read out in the returned List.
      * @return A List of lines ordered with the newest entries at the head of the List.
      */
-    List<String> getLastNLines(Path path, @Nullable String filter, int count);
+    List<String> getLastNLines(Path path, @Nullable String filter, int start, int count);
 }

--- a/src/main/java/qlog/TailReader.java
+++ b/src/main/java/qlog/TailReader.java
@@ -9,10 +9,10 @@ public interface TailReader {
     /**
      * Get the last N lines from a file.
      *
-     * @param path      A path to the file to read lines from.
-     * @param lineCount The number of lines to read out in the returned List.
-     * @param filter    If present, a line is counted only when it matches the filter.
+     * @param path   A path to the file to read lines from.
+     * @param filter If present, a line is counted only when it matches the filter.
+     * @param count  The number of lines to read out in the returned List.
      * @return A List of lines ordered with the newest entries at the head of the List.
      */
-    List<String> getLastNLines(Path path, int lineCount, @Nullable String filter);
+    List<String> getLastNLines(Path path, @Nullable String filter, int count);
 }

--- a/src/main/java/qlog/TailReaderImpl.java
+++ b/src/main/java/qlog/TailReaderImpl.java
@@ -123,14 +123,14 @@ public class TailReaderImpl implements TailReader {
                     // chunk.
                     var c = (char) bb.get(i);
                     if (c == '\n') {
+                        // Skip the first line-ending we encounter (e.g. if the last character in
+                        // the file is a line-ending).
+                        if (chunkStart + i + 1 == remainingBytes) continue;
                         // Set the position in the buffer to the current byte position of the
                         // line-ending so that we can read the position as the continuation
                         // token. This is necessary because the position of the buffer never
                         // changes since we're using absolute reads from the buffer.
                         bb.position(i);
-                        // Skip the first line-ending we encounter (e.g. if the last character in
-                        // the file is a line-ending).
-                        if (i == fileSize - 1) continue;
                         // We've encountered a line ending that is not the end of the file
                         linesSeen += 1;
                         // If we've seen enough lines to start collecting results and the line

--- a/src/main/java/qlog/TailReaderImpl.java
+++ b/src/main/java/qlog/TailReaderImpl.java
@@ -67,7 +67,14 @@ public class TailReaderImpl implements TailReader {
             // If a continuation token is provided, then we want to start reading the file from
             // the byte position of the continuation token. Otherwise, we start reading from the
             // end of the file.
-            long remainingBytes = Optional.ofNullable(continuationToken)
+            var maybeContinuationToken = Optional.ofNullable(continuationToken);
+            if (maybeContinuationToken.isPresent()) {
+                // If the continuation token is present, then we want to start reading the file
+                // from the byte position of the continuation token. So we effectively ignore
+                // the start parameter.
+                start = 0;
+            }
+            long remainingBytes = maybeContinuationToken
                     .map(Long::parseLong)
                     .orElse(fileSize);
             // Initialize a counter to keep track of how many lines we've seen. This reader

--- a/src/main/java/qlog/TailReaderImpl.java
+++ b/src/main/java/qlog/TailReaderImpl.java
@@ -32,7 +32,7 @@ public class TailReaderImpl implements TailReader {
      * {@inheritDoc}
      */
     @Override
-    public List<String> getLastNLines(Path path, int lineCount, @Nullable String filter) {
+    public List<String> getLastNLines(Path path, @Nullable String filter, int count) {
         // Each chunk of the file will be read into this buffer
         var bb = ByteBuffer.allocate(this.bufferCapacity);
 
@@ -63,7 +63,7 @@ public class TailReaderImpl implements TailReader {
             var bytesRead = 0;
             // Chunk through the file while the collectedLines size is less than the lineCount
             // or we've read all the bytes in the file.
-            while (collectedLines.size() < lineCount || bytesRead < ch.size()) {
+            while (collectedLines.size() < count || bytesRead < ch.size()) {
                 if (bytesRead > 0) {
                     // Each time we start a new chunk, we want to dynamically size the limit
                     // of the byte buffer so that we only read the bytes necessary to complete
@@ -100,7 +100,7 @@ public class TailReaderImpl implements TailReader {
                             continue;
                         }
                         maybeCollectLine(lineBuffer, filter, collectedLines);
-                        if (collectedLines.size() >= lineCount) {
+                        if (collectedLines.size() >= count) {
                             // break out of looping through this chunk if we have enough lines
                             break;
                         }
@@ -117,7 +117,7 @@ public class TailReaderImpl implements TailReader {
                 }
                 // Stop chunking when we have enough lines collected,
                 // or we've read all the bytes from the file.
-                if (collectedLines.size() == lineCount || bytesRead >= ch.size()) {
+                if (collectedLines.size() == count || bytesRead >= ch.size()) {
                     break;
                 }
                 // Otherwise, prepare for the next chunk by stepping start backwards by the size

--- a/src/main/java/qlog/controllers/QueryLogController.java
+++ b/src/main/java/qlog/controllers/QueryLogController.java
@@ -9,6 +9,10 @@ import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.micronaut.serde.annotation.Serdeable.Serializable;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import qlog.TailReader;
 
 import java.nio.file.Path;
@@ -27,21 +31,51 @@ public class QueryLogController {
     /**
      * Reads the "tail" of a file in /var/log.
      *
-     * @param relativePath The relativePath used to resolve a file. E.g., "syslog" resolves to <code>/var/log/syslog</code>.
-     * @param count        The number of lines to tail in the file.
+     * @param relativePath      The relativePath used to resolve a file. E.g., "syslog" resolves to
+     *                          <code>/var/log/syslog</code>. The relativePath must be a non-empty
+     *                          string.
+     * @param filter            A filter to apply to the lines. If null, no filter is applied and
+     *                          all lines are returned.
+     * @param start             The starting line number to tail in the file. If 0, the tail
+     *                          starts at the end of the file.
+     * @param count             The number of lines to tail in the file. Must be a positive
+     *                          integer. The maximum value allowed is 10,000. Specifying a value
+     *                          greater than 10,000 will result in a 400 Bad Request. If the file
+     *                          contains more lines than are specified in the count the response
+     *                          will contain a continuation token that can be used to retrieve the
+     *                          next set of lines.
+     * @param continuationToken A token that can be used to retrieve the "next" set of lines from
+     *                          the file. If the token is present, start and count are ignored and
+     *                          the file is read from the last position of the previous request
+     *                          using the same "count" parameter used in the previous request.
+     *                          If null, the file is read according to the start and count
+     *                          parameters and a continuationToken for this file will be returned
+     *                          in the response metadata.
      * @return A 200 OK containing the requested lines from the file.
      */
     @Get
     @ExecuteOn(TaskExecutors.BLOCKING)
-    public HttpResponse<QueryLog> queryLog(@QueryValue String relativePath,
-                                           @QueryValue(defaultValue = "42") int count,
-                                           @QueryValue @Nullable String filter) {
+    public HttpResponse<QueryLog> queryLog(@QueryValue @NotBlank String relativePath,
+                                           @QueryValue @Nullable String filter,
+                                           @QueryValue(defaultValue = "0") @PositiveOrZero int start,
+                                           @QueryValue(defaultValue = "1000") @Positive @Max(value = 10_000) int count,
+                                           @QueryValue @Nullable String continuationToken) {
         var lines = this.tailReader.getLastNLines(Path.of("/var/log", relativePath), count, filter);
-        return HttpResponse.ok(new QueryLog(lines));
+        // TODO: Get the next continuation token from the tailReader
+        //       Return the continuation token in the metadata of the response.
+        return HttpResponse.ok(new QueryLog(lines, null));
     }
 
     @Serializable
-    public record QueryLog(List<String> data) {
+    public record QueryLog(List<String> data, @Nullable Metadata metadata) {
+    }
+
+    @Serializable
+    public record Metadata(ContinuationToken continuationToken) {
+    }
+
+    @Serializable
+    public record ContinuationToken(String token) {
     }
 
 }

--- a/src/main/java/qlog/controllers/QueryLogController.java
+++ b/src/main/java/qlog/controllers/QueryLogController.java
@@ -60,10 +60,10 @@ public class QueryLogController {
                                            @QueryValue(defaultValue = "0") @PositiveOrZero int start,
                                            @QueryValue(defaultValue = "1000") @Positive @Max(value = 10_000) int count,
                                            @QueryValue @Nullable String continuationToken) {
-        var lines = this.tailReader.getLastNLines(Path.of("/var/log", relativePath), filter, start, count);
+        var result = this.tailReader.getLastNLines(Path.of("/var/log", relativePath), filter, start, count);
         // TODO: Get the next continuation token from the tailReader
         //       Return the continuation token in the metadata of the response.
-        return HttpResponse.ok(new QueryLog(lines, null));
+        return HttpResponse.ok(new QueryLog(result.lines(), null));
     }
 
     @Serializable

--- a/src/main/java/qlog/controllers/QueryLogController.java
+++ b/src/main/java/qlog/controllers/QueryLogController.java
@@ -60,10 +60,12 @@ public class QueryLogController {
                                            @QueryValue(defaultValue = "0") @PositiveOrZero int start,
                                            @QueryValue(defaultValue = "1000") @Positive @Max(value = 10_000) int count,
                                            @QueryValue @Nullable String continuationToken) {
-        var result = this.tailReader.getLastNLines(Path.of("/var/log", relativePath), filter, null, start, count);
-        // TODO: Get the next continuation token from the tailReader
-        //       Return the continuation token in the metadata of the response.
-        return HttpResponse.ok(new QueryLog(result.lines(), null));
+        var result = this.tailReader.getLastNLines(Path.of("/var/log", relativePath), filter, continuationToken, start, count);
+        return HttpResponse.ok(new QueryLog(
+                result.lines(),
+                result.continuationToken()
+                        .map(token -> new Metadata(new ContinuationToken(token)))
+                        .orElse(null)));
     }
 
     @Serializable

--- a/src/main/java/qlog/controllers/QueryLogController.java
+++ b/src/main/java/qlog/controllers/QueryLogController.java
@@ -60,7 +60,7 @@ public class QueryLogController {
                                            @QueryValue(defaultValue = "0") @PositiveOrZero int start,
                                            @QueryValue(defaultValue = "1000") @Positive @Max(value = 10_000) int count,
                                            @QueryValue @Nullable String continuationToken) {
-        var lines = this.tailReader.getLastNLines(Path.of("/var/log", relativePath), count, filter);
+        var lines = this.tailReader.getLastNLines(Path.of("/var/log", relativePath), filter, count);
         // TODO: Get the next continuation token from the tailReader
         //       Return the continuation token in the metadata of the response.
         return HttpResponse.ok(new QueryLog(lines, null));

--- a/src/main/java/qlog/controllers/QueryLogController.java
+++ b/src/main/java/qlog/controllers/QueryLogController.java
@@ -60,7 +60,7 @@ public class QueryLogController {
                                            @QueryValue(defaultValue = "0") @PositiveOrZero int start,
                                            @QueryValue(defaultValue = "1000") @Positive @Max(value = 10_000) int count,
                                            @QueryValue @Nullable String continuationToken) {
-        var lines = this.tailReader.getLastNLines(Path.of("/var/log", relativePath), filter, count);
+        var lines = this.tailReader.getLastNLines(Path.of("/var/log", relativePath), filter, start, count);
         // TODO: Get the next continuation token from the tailReader
         //       Return the continuation token in the metadata of the response.
         return HttpResponse.ok(new QueryLog(lines, null));

--- a/src/main/java/qlog/controllers/QueryLogController.java
+++ b/src/main/java/qlog/controllers/QueryLogController.java
@@ -60,7 +60,7 @@ public class QueryLogController {
                                            @QueryValue(defaultValue = "0") @PositiveOrZero int start,
                                            @QueryValue(defaultValue = "1000") @Positive @Max(value = 10_000) int count,
                                            @QueryValue @Nullable String continuationToken) {
-        var result = this.tailReader.getLastNLines(Path.of("/var/log", relativePath), filter, start, count);
+        var result = this.tailReader.getLastNLines(Path.of("/var/log", relativePath), filter, null, start, count);
         // TODO: Get the next continuation token from the tailReader
         //       Return the continuation token in the metadata of the response.
         return HttpResponse.ok(new QueryLog(result.lines(), null));

--- a/src/test/java/qlog/TailReaderTest.java
+++ b/src/test/java/qlog/TailReaderTest.java
@@ -134,6 +134,22 @@ public class TailReaderTest implements WithAssertions {
         assertThat(actual).containsExactly("The way to dusty death. Out, out, brief candle!");
     }
 
+    @Test
+    void returnsContinuationTokenWhenThereAreMoreBytesToReadInTheFile() {
+        var path = getPathToResource("macbeth.txt");
+        var reader = new TailReaderImpl(16);
+        var result = reader.getLastNLines(path, null, 0, 1);
+        assertThat(result.continuationToken()).isNotEmpty();
+    }
+
+    @Test
+    void noContinuationTokenWhenFinishedReadingTheFile() {
+        var path = getPathToResource("smallfile");
+        var reader = new TailReaderImpl(16);
+        var result = reader.getLastNLines(path, null, 0, 1);
+        assertThat(result.continuationToken()).isEmpty();
+    }
+
     @SuppressWarnings("SameParameterValue")
     private Path getPathToResource(String fileName) {
         var resourceURL = getClass().getClassLoader().getResource(fileName);

--- a/src/test/java/qlog/TailReaderTest.java
+++ b/src/test/java/qlog/TailReaderTest.java
@@ -19,7 +19,7 @@ public class TailReaderTest implements WithAssertions {
     void returnsLastNLinesInFile() {
         var file = getPathToResource("macbeth.txt");
         var n = 3;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(file, null, n);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(file, null, 0, n);
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -36,7 +36,7 @@ public class TailReaderTest implements WithAssertions {
     void fileLargerThanBufferReturnsLastNLinesInFile() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = 5;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, n);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n);
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -52,7 +52,7 @@ public class TailReaderTest implements WithAssertions {
     void largeCountOfFilesCollectsLinesAcrossChunkBoundaries() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = 250;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, n);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n);
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -68,7 +68,7 @@ public class TailReaderTest implements WithAssertions {
     void readingAllOfTheLinesInAFileReturnsTheLinesInReversedOrder() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = (int) Files.lines(path).count(); // all lines
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, n);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n);
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -82,7 +82,7 @@ public class TailReaderTest implements WithAssertions {
     @Test
     void onlyLinesMatchingFilterAreReturned() {
         var path = getPathToResource("macbeth.txt");
-        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, "tomorrow", 1);
+        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, "tomorrow", 0, 1);
         assertThat(actual).hasSize(1);
         assertThat(actual).containsExactlyElementsOf(List.of("Tomorrow, and tomorrow, and tomorrow,"));
     }
@@ -90,7 +90,7 @@ public class TailReaderTest implements WithAssertions {
     @Test
     void multipleLinesMatchingFilterAreReturned() {
         var path = getPathToResource("macbeth.txt");
-        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, ",", 3);
+        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, ",", 0, 3);
         assertThat(actual).hasSize(3);
         assertThat(actual)
                 .containsExactlyElementsOf(List.of(
@@ -104,7 +104,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("smallfile");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 10))
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 0, 10))
                         .isEmpty());
     }
 
@@ -113,7 +113,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("macbeth.txt");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 10))
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 0, 10))
                         .isEmpty());
     }
 
@@ -122,7 +122,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("empty.txt");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, null, 10))
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, null, 0, 10))
                         .isEmpty());
     }
 

--- a/src/test/java/qlog/TailReaderTest.java
+++ b/src/test/java/qlog/TailReaderTest.java
@@ -126,6 +126,14 @@ public class TailReaderTest implements WithAssertions {
                         .isEmpty());
     }
 
+    @Test
+    void skipsLinesWhenStartIsGreaterThanZero() {
+        var path = getPathToResource("macbeth.txt");
+        var reader = new TailReaderImpl(65536);
+        var actual = reader.getLastNLines(path, null, 5, 1).lines();
+        assertThat(actual).containsExactly("The way to dusty death. Out, out, brief candle!");
+    }
+
     @SuppressWarnings("SameParameterValue")
     private Path getPathToResource(String fileName) {
         var resourceURL = getClass().getClassLoader().getResource(fileName);

--- a/src/test/java/qlog/TailReaderTest.java
+++ b/src/test/java/qlog/TailReaderTest.java
@@ -1,6 +1,7 @@
 package qlog;
 
 import org.assertj.core.api.WithAssertions;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -148,6 +149,21 @@ public class TailReaderTest implements WithAssertions {
         var reader = new TailReaderImpl(16);
         var result = reader.getLastNLines(path, null, null, 0, 1);
         assertThat(result.continuationToken()).isEmpty();
+    }
+
+    @Test
+    void continuationTokenIsUsedToReadMoreLines() {
+        var path = getPathToResource("macbeth.txt");
+        var reader = new TailReaderImpl(16);
+        var result = reader.getLastNLines(path, null, null, 0, 2);
+        assertThat(result.lines())
+                .as("The last two lines are read from the file.")
+                .containsExactly("Signifying nothing.", "Told by an idiot, full of sound and fury,");
+        var continuationToken = result.continuationToken().orElseThrow();
+        var moreLines = reader.getLastNLines(path, null, continuationToken, 0, 1).lines();
+        assertThat(moreLines)
+                .as("The next line is read from the file (third from the end).")
+                .containsExactly("And then is heard no more. It is a tale");
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/test/java/qlog/TailReaderTest.java
+++ b/src/test/java/qlog/TailReaderTest.java
@@ -166,6 +166,21 @@ public class TailReaderTest implements WithAssertions {
                 .containsExactly("And then is heard no more. It is a tale");
     }
 
+    @Test
+    void startIsIgnoredWhenContinuationTokenIsPresent() {
+        var path = getPathToResource("macbeth.txt");
+        var reader = new TailReaderImpl(16);
+        var result = reader.getLastNLines(path, null, null, 0, 2);
+        assertThat(result.lines())
+                .as("The last two lines are read from the file.")
+                .containsExactly("Signifying nothing.", "Told by an idiot, full of sound and fury,");
+        var continuationToken = result.continuationToken().orElseThrow();
+        var moreLines = reader.getLastNLines(path, null, continuationToken, 1, 1).lines();
+        assertThat(moreLines)
+                .as("The next line is read from the file, the start parameter is ignored.")
+                .containsExactly("And then is heard no more. It is a tale");
+    }
+
     @SuppressWarnings("SameParameterValue")
     private Path getPathToResource(String fileName) {
         var resourceURL = getClass().getClassLoader().getResource(fileName);

--- a/src/test/java/qlog/TailReaderTest.java
+++ b/src/test/java/qlog/TailReaderTest.java
@@ -19,7 +19,7 @@ public class TailReaderTest implements WithAssertions {
     void returnsLastNLinesInFile() {
         var file = getPathToResource("macbeth.txt");
         var n = 3;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(file, null, 0, n);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(file, null, 0, n).lines();
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -36,7 +36,7 @@ public class TailReaderTest implements WithAssertions {
     void fileLargerThanBufferReturnsLastNLinesInFile() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = 5;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n).lines();
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -52,7 +52,7 @@ public class TailReaderTest implements WithAssertions {
     void largeCountOfFilesCollectsLinesAcrossChunkBoundaries() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = 250;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n).lines();
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -68,7 +68,7 @@ public class TailReaderTest implements WithAssertions {
     void readingAllOfTheLinesInAFileReturnsTheLinesInReversedOrder() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = (int) Files.lines(path).count(); // all lines
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n).lines();
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -82,7 +82,7 @@ public class TailReaderTest implements WithAssertions {
     @Test
     void onlyLinesMatchingFilterAreReturned() {
         var path = getPathToResource("macbeth.txt");
-        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, "tomorrow", 0, 1);
+        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, "tomorrow", 0, 1).lines();
         assertThat(actual).hasSize(1);
         assertThat(actual).containsExactlyElementsOf(List.of("Tomorrow, and tomorrow, and tomorrow,"));
     }
@@ -90,7 +90,7 @@ public class TailReaderTest implements WithAssertions {
     @Test
     void multipleLinesMatchingFilterAreReturned() {
         var path = getPathToResource("macbeth.txt");
-        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, ",", 0, 3);
+        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, ",", 0, 3).lines();
         assertThat(actual).hasSize(3);
         assertThat(actual)
                 .containsExactlyElementsOf(List.of(
@@ -104,7 +104,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("smallfile");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 0, 10))
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 0, 10).lines())
                         .isEmpty());
     }
 
@@ -113,7 +113,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("macbeth.txt");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 0, 10))
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 0, 10).lines())
                         .isEmpty());
     }
 
@@ -122,7 +122,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("empty.txt");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, null, 0, 10))
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, null, 0, 10).lines())
                         .isEmpty());
     }
 

--- a/src/test/java/qlog/TailReaderTest.java
+++ b/src/test/java/qlog/TailReaderTest.java
@@ -19,7 +19,7 @@ public class TailReaderTest implements WithAssertions {
     void returnsLastNLinesInFile() {
         var file = getPathToResource("macbeth.txt");
         var n = 3;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(file, n, null);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(file, null, n);
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -36,7 +36,7 @@ public class TailReaderTest implements WithAssertions {
     void fileLargerThanBufferReturnsLastNLinesInFile() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = 5;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, n, null);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, n);
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -52,7 +52,7 @@ public class TailReaderTest implements WithAssertions {
     void largeCountOfFilesCollectsLinesAcrossChunkBoundaries() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = 250;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, n, null);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, n);
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -68,7 +68,7 @@ public class TailReaderTest implements WithAssertions {
     void readingAllOfTheLinesInAFileReturnsTheLinesInReversedOrder() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = (int) Files.lines(path).count(); // all lines
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, n, null);
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, n);
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -82,7 +82,7 @@ public class TailReaderTest implements WithAssertions {
     @Test
     void onlyLinesMatchingFilterAreReturned() {
         var path = getPathToResource("macbeth.txt");
-        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, 1, "tomorrow");
+        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, "tomorrow", 1);
         assertThat(actual).hasSize(1);
         assertThat(actual).containsExactlyElementsOf(List.of("Tomorrow, and tomorrow, and tomorrow,"));
     }
@@ -90,7 +90,7 @@ public class TailReaderTest implements WithAssertions {
     @Test
     void multipleLinesMatchingFilterAreReturned() {
         var path = getPathToResource("macbeth.txt");
-        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, 3, ",");
+        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, ",", 3);
         assertThat(actual).hasSize(3);
         assertThat(actual)
                 .containsExactlyElementsOf(List.of(
@@ -104,7 +104,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("smallfile");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, 10, "WONTFIND"))
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 10))
                         .isEmpty());
     }
 
@@ -113,7 +113,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("macbeth.txt");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, 10, "WONTFIND"))
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 10))
                         .isEmpty());
     }
 
@@ -122,7 +122,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("empty.txt");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, 10, null))
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, null, 10))
                         .isEmpty());
     }
 

--- a/src/test/java/qlog/TailReaderTest.java
+++ b/src/test/java/qlog/TailReaderTest.java
@@ -19,7 +19,7 @@ public class TailReaderTest implements WithAssertions {
     void returnsLastNLinesInFile() {
         var file = getPathToResource("macbeth.txt");
         var n = 3;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(file, null, 0, n).lines();
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(file, null, null, 0, n).lines();
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -36,7 +36,7 @@ public class TailReaderTest implements WithAssertions {
     void fileLargerThanBufferReturnsLastNLinesInFile() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = 5;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n).lines();
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, null, 0, n).lines();
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -52,7 +52,7 @@ public class TailReaderTest implements WithAssertions {
     void largeCountOfFilesCollectsLinesAcrossChunkBoundaries() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = 250;
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n).lines();
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, null, 0, n).lines();
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -68,7 +68,7 @@ public class TailReaderTest implements WithAssertions {
     void readingAllOfTheLinesInAFileReturnsTheLinesInReversedOrder() throws IOException {
         var path = getPathToResource("128k_access.log");
         var n = (int) Files.lines(path).count(); // all lines
-        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, 0, n).lines();
+        List<String> lastNLines = new TailReaderImpl(65536).getLastNLines(path, null, null, 0, n).lines();
 
         assertThat(lastNLines)
                 .as("The last N lines were read from the file.")
@@ -82,7 +82,7 @@ public class TailReaderTest implements WithAssertions {
     @Test
     void onlyLinesMatchingFilterAreReturned() {
         var path = getPathToResource("macbeth.txt");
-        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, "tomorrow", 0, 1).lines();
+        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, "tomorrow", null, 0, 1).lines();
         assertThat(actual).hasSize(1);
         assertThat(actual).containsExactlyElementsOf(List.of("Tomorrow, and tomorrow, and tomorrow,"));
     }
@@ -90,7 +90,7 @@ public class TailReaderTest implements WithAssertions {
     @Test
     void multipleLinesMatchingFilterAreReturned() {
         var path = getPathToResource("macbeth.txt");
-        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, ",", 0, 3).lines();
+        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, ",", null, 0, 3).lines();
         assertThat(actual).hasSize(3);
         assertThat(actual)
                 .containsExactlyElementsOf(List.of(
@@ -104,7 +104,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("smallfile");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 0, 10).lines())
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", null, 0, 10).lines())
                         .isEmpty());
     }
 
@@ -113,7 +113,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("macbeth.txt");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", 0, 10).lines())
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, "WONTFIND", null, 0, 10).lines())
                         .isEmpty());
     }
 
@@ -122,7 +122,7 @@ public class TailReaderTest implements WithAssertions {
         var path = getPathToResource("empty.txt");
         var reader = new TailReaderImpl(65536);
         await().atMost(1, TimeUnit.SECONDS)
-                .untilAsserted(() -> assertThat(reader.getLastNLines(path, null, 0, 10).lines())
+                .untilAsserted(() -> assertThat(reader.getLastNLines(path, null, null, 0, 10).lines())
                         .isEmpty());
     }
 
@@ -130,7 +130,7 @@ public class TailReaderTest implements WithAssertions {
     void skipsLinesWhenStartIsGreaterThanZero() {
         var path = getPathToResource("macbeth.txt");
         var reader = new TailReaderImpl(65536);
-        var actual = reader.getLastNLines(path, null, 5, 1).lines();
+        var actual = reader.getLastNLines(path, null, null, 5, 1).lines();
         assertThat(actual).containsExactly("The way to dusty death. Out, out, brief candle!");
     }
 
@@ -138,7 +138,7 @@ public class TailReaderTest implements WithAssertions {
     void returnsContinuationTokenWhenThereAreMoreBytesToReadInTheFile() {
         var path = getPathToResource("macbeth.txt");
         var reader = new TailReaderImpl(16);
-        var result = reader.getLastNLines(path, null, 0, 1);
+        var result = reader.getLastNLines(path, null, null, 0, 1);
         assertThat(result.continuationToken()).isNotEmpty();
     }
 
@@ -146,7 +146,7 @@ public class TailReaderTest implements WithAssertions {
     void noContinuationTokenWhenFinishedReadingTheFile() {
         var path = getPathToResource("smallfile");
         var reader = new TailReaderImpl(16);
-        var result = reader.getLastNLines(path, null, 0, 1);
+        var result = reader.getLastNLines(path, null, null, 0, 1);
         assertThat(result.continuationToken()).isEmpty();
     }
 


### PR DESCRIPTION
This PR addresses issues raised in #3 where retrieving a large number of lines from a large file would result in high CPU utilization by the server.

Previously, the only way to get all of the lines from a file was to request an arbitrarily large `count` to mimic a "get all" behavior. The large size of the lines to return caused significant overhead for JSON serialization.

To address the performance issues this PR:
1. Enforces a maximum value for count at 10k entries.
2. Provides a `continuationToken` to allow for consistent pagination through the entries in the log file.

With this PR the server keeps track of the line-endings seen by the file reader and returns a continuation token in the response metadata that can be sent back to the server with the next request.

The server also adds support for a `start` parameter as a low watermark to skip lines seen in the file until the watermark is reached and only then start collecting. The continuationToken is preferred since it is more efficient with respect to disk I/O and doesn't require reading regions of the file that would never return data.

Examples:

```shell
% time curl -Ss "localhost:8080/queryLog?relativePath=access.log&count=10000" | jq .metadata
{
  "continuationToken": {
    "token": "2005886425"
  }
}
curl 0.00s user 0.00s system 19% cpu 0.029 total
jq   0.02s user 0.00s system 74% cpu 0.029 total
```

```shell
time curl -Ss "localhost:8080/queryLog?relativePath=access.log&count=10000&continuationToken=2005886425" | jq .metadata
{
  "continuationToken": {
    "token": "2005886434"
  }
}
curl 0.00s user 0.01s system 19% cpu 0.030 total
jq   0.02s user 0.00s system 69% cpu 0.030 total
```

If the count is too large a 400 Bad Request is returned:

```shell
curl -i -Ss "localhost:8080/queryLog?relativePath=access.log&count=99999" | head -n1
HTTP/1.1 400 Bad Request
```

If an entire file is read in one request, the server does not return a continuationToken. Clients can use this as a signal that there are no more entries to read.

```shell
% wc -l /var/log/dmesg                                                                                                   
1556 /var/log/dmesg
% curl -Ss "localhost:8080/queryLog?relativePath=dmesg&count=1556" | jq .metadata 
null
```