### PR TITLE
Fix Integer Overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ out/
 .classpath
 .factorypath
 bin/
+log/*

--- a/src/main/java/qlog/TailReaderImpl.java
+++ b/src/main/java/qlog/TailReaderImpl.java
@@ -79,7 +79,7 @@ public class TailReaderImpl implements TailReader {
                     .orElse(fileSize);
             // Initialize a counter to keep track of how many lines we've seen. This reader
             // will skip lines until linesSeen is equal to start.
-            var linesSeen = 0;
+            var linesSeen = 0L;
             // The start of the chunk is the end (channel size) minus the capacity (limit) of the buffer.
             // If the file is smaller than the buffer we do not allow start to be negative so take the max of 0.
             var chunkStart = Math.max(0, remainingBytes - bb.limit());
@@ -89,7 +89,7 @@ public class TailReaderImpl implements TailReader {
             var lineBuffer = new StringBuilder();
             // Keep track of how many bytes we read from the file so that we can stop from reading
             // the head of the file multiple times.
-            var bytesRead = 0;
+            var bytesRead = 0L;
             // Chunk through the file while the collectedLines size is less than the lineCount
             // or we've read all the bytes in the file.
             while (collectedLines.size() < count || bytesRead < fileSize) {
@@ -101,8 +101,11 @@ public class TailReaderImpl implements TailReader {
                     // that were already read in a previous chunk.
                     //
                     // We use min(CAP, remainingBytes - bytesRead) to avoid setting a larger limit
-                    // that what the buffer was allocated with.
-                    bb.limit(Math.min(this.bufferCapacity, (int) remainingBytes - bytesRead));
+                    // that what the buffer initially was allocated with.
+                    if (remainingBytes - bytesRead < this.bufferCapacity) {
+                        // the initial buffer capacity is an int, so this is a safe cast.
+                        bb.limit((int)(remainingBytes - bytesRead));
+                    }
                 }
                 // Set the position of the channel to the start of the chunk.
                 ch.position(chunkStart);

--- a/src/main/java/qlog/TailReaderImpl.java
+++ b/src/main/java/qlog/TailReaderImpl.java
@@ -49,6 +49,10 @@ public class TailReaderImpl implements TailReader {
         // line count.
         @Nullable String nextToken = null;
 
+        LOG.atInfo().log("Reading file at path: {}, filter: {}, lineCount: {}",
+                path, filter, count);
+        var startNs = System.nanoTime();
+
         // Open a seekable channel to the file so that we can read chunks of the file starting
         // at the end. The start of each read will be determined as the byte-position end of the
         // file minus the capacity of the byte buffer. Each "step" will move the start backwards
@@ -181,7 +185,11 @@ public class TailReaderImpl implements TailReader {
                 LOG.error("Error reading file: {}", path, e);
                 throw new TailReaderIOException("Error reading file: " + path, e);
             }
+        } finally {
+            var durationNs = System.nanoTime() - startNs;
+            LOG.atInfo().log("Finished reading file at path: {}, duration: {}ms", path, durationNs / 1_000_000 );
         }
+        LOG.atInfo().log("File at path: {}, {} lines collected", path, collectedLines.size());
         return new ReaderResult(collectedLines, Optional.ofNullable(nextToken));
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 #Sat Feb 10 14:06:37 MST 2024
 micronaut.application.name=qlog
 qlog.tail.buffer.capacity=65536
+micronaut.server.netty.access-logger.enabled=true
+micronaut.server.netty.access-logger.log-format=%h %l %u %t "%r" %s %b %Dms

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,8 +1,35 @@
 <configuration>
 
+    <appender
+            name="httpAccessLogAppender"
+            class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <append>true</append>
+        <file>log/http-access.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>log/http-access-%d{yyyy-MM-dd}.log
+            </fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <charset>UTF-8</charset>
+            <pattern>%msg%n</pattern>
+        </encoder>
+        <immediateFlush>true</immediateFlush>
+    </appender>
+
+    <logger name="HTTP_ACCESS_LOGGER" additivity="false" level="info">
+        <appender-ref ref="httpAccessLogAppender" />
+        <appender-ref ref="ACCESS_STDOUT" />
+    </logger>
+
+    <appender name="ACCESS_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- encoders are assigned the type
-             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
             <pattern>%cyan(%d{HH:mm:ss.SSS}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
When reading from a very large file the references to bookkeeping how many bytes are remaining and how many bytes have been read from the file would overflow causing the buffer limit to be set to zero.

When the buffer limit is set to zero the channel wouldn't read any more bytes from the file and the reader would effectively spin-lock at the current position and halt any progress on reading the file.

The result of the spinlock would be a runaway process that would never get killed. A client requesting the lines would hang up on the request since the server never returned any data.

This commit updates the bookkeeping references in the reader implementation to be a long type instead of int. Furthermore, it refactors the logic to limit the buffer when at the head of the file to safely cast the new limit to an integer.

Related to #3 