### PR TITLE
Add a timeout while reading data

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     annotationProcessor("io.micronaut.validation:micronaut-validation-processor")
     implementation("io.micronaut.validation:micronaut-validation")
     implementation("io.micronaut.serde:micronaut-serde-jackson")
+    implementation("dev.failsafe:failsafe:3.3.2")
     compileOnly("io.micronaut:micronaut-http-client")
     runtimeOnly("ch.qos.logback:logback-classic")
     testImplementation("io.micronaut:micronaut-http-client")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 #Sat Feb 10 14:06:37 MST 2024
 micronaut.application.name=qlog
 qlog.tail.buffer.capacity=65536
+micronaut.server.idle-timeout=65s
 micronaut.server.netty.access-logger.enabled=true
 micronaut.server.netty.access-logger.log-format=%h %l %u %t "%r" %s %b %Dms


### PR DESCRIPTION
- If reading from the file takes too long the server was configured by default to hang-up the request after 5 minutes but there was no error message only an "empty response".
- This PR adds a timeout handler using [Failsafe](https://failsafe.dev) to interrupt the reader and return a 504 Gateway Timeout when the reader takes too long.

See #3 for more discussion about the timeout.