### PR TITLE
Fix missing array in response when list is empty

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,4 @@ qlog.tail.buffer.capacity=65536
 micronaut.server.idle-timeout=65s
 micronaut.server.netty.access-logger.enabled=true
 micronaut.server.netty.access-logger.log-format=%h %l %u %t "%r" %s %b %Dms
+micronaut.serde.serialization.inclusion=non_absent


### PR DESCRIPTION
Micronaut serializer by default will exclude keys where the value is null or empty. This commit adjusts the serializer inclusion property to include `non_absent` values, e.g. empty lists (or maps).