### PR TITLE
Implement early termination

### DIFF
--- a/src/main/java/qlog/TailReaderImpl.java
+++ b/src/main/java/qlog/TailReaderImpl.java
@@ -145,7 +145,7 @@ public class TailReaderImpl implements TailReader {
                         if (!lineBuffer.isEmpty() && linesSeen >= start) {
                             maybeCollectLine(lineBuffer, filter, collectedLines);
                         }
-                        if (collectedLines.size() >= count) {
+                        if (linesSeen >= start && (linesSeen == count || collectedLines.size() == count)) {
                             // break out of looping through this chunk if we have enough lines
                             break;
                         }
@@ -163,7 +163,7 @@ public class TailReaderImpl implements TailReader {
                 }
                 // Stop chunking when we have enough lines collected,
                 // or we've read all the bytes from the file.
-                if (collectedLines.size() == count || bytesRead >= fileSize) {
+                if (linesSeen == count || collectedLines.size() == count || bytesRead >= fileSize) {
                     if (bytesRead < fileSize) {
                         // If there are more bytes to read in the file, then set the continuation
                         // token to the byte position of the last line-ending seen in the file.

--- a/src/test/java/qlog/TailReaderTest.java
+++ b/src/test/java/qlog/TailReaderTest.java
@@ -83,7 +83,7 @@ public class TailReaderTest implements WithAssertions {
     @Test
     void onlyLinesMatchingFilterAreReturned() {
         var path = getPathToResource("macbeth.txt");
-        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, "tomorrow", null, 0, 1).lines();
+        List<String> actual = new TailReaderImpl(65536).getLastNLines(path, "tomorrow", null, 0, 10).lines();
         assertThat(actual).hasSize(1);
         assertThat(actual).containsExactlyElementsOf(List.of("Tomorrow, and tomorrow, and tomorrow,"));
     }
@@ -92,12 +92,11 @@ public class TailReaderTest implements WithAssertions {
     void multipleLinesMatchingFilterAreReturned() {
         var path = getPathToResource("macbeth.txt");
         List<String> actual = new TailReaderImpl(65536).getLastNLines(path, ",", null, 0, 3).lines();
-        assertThat(actual).hasSize(3);
         assertThat(actual)
-                .containsExactlyElementsOf(List.of(
-                        "Told by an idiot, full of sound and fury,",
-                        "That struts and frets his hour upon the stage,",
-                        "Life's but a walking shadow, a poor player,"));
+                .as("The first three lines are read and only one has a comma char")
+                .hasSize(1);
+        assertThat(actual)
+                .containsExactlyElementsOf(List.of("Told by an idiot, full of sound and fury,"));
     }
 
     @Test


### PR DESCRIPTION
Adjust the reader to exit when the linesSeen equals the count parameter OR the lines collected equals the count parameter. The first condition to reach will break out of the buffer/chunk loop and return the results with a continuation token if there are more bytes to read.